### PR TITLE
Include calloc() etc. Wasn't compiling with recent GCC versions.

### DIFF
--- a/include/crfsuite.hpp
+++ b/include/crfsuite.hpp
@@ -37,6 +37,7 @@
 #include <stdexcept>
 #include <iostream>
 #include <sstream>
+#include <cstdlib>
 
 #include <crfsuite.h>
 #include "crfsuite_api.hpp"


### PR DESCRIPTION
Without `cstdlib`, compilation of e.g. NERsuite against `crfsuite.hpp` was failing with

```
/usr/local/include/crfsuite.hpp:332: error: ‘calloc’ was not declared in this scope
/usr/local/include/crfsuite.hpp:353: error: ‘exit’ was not declared in this scope
/usr/local/include/crfsuite.hpp:361: error: ‘atof’ was not declared in this scope
/usr/local/include/crfsuite.hpp:374: error: ‘free’ was not declared in this scope
```

this line fixes the issue.
